### PR TITLE
Update discord-video-stream to version 6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "ysdragon",
   "license": "MIT",
   "dependencies": {
-    "@dank074/discord-video-stream": "5.0.1",
+    "@dank074/discord-video-stream": "6.0.0",
     "@types/bcrypt": "^6.0.0",
     "@types/bun": "^1.3.8",
     "argon2": "^0.44.0",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade the Discord video streaming dependency to v6.0.0 to pick up upstream fixes and updates. This is a major bump, so please verify video streaming flows for breaking changes.

- **Dependencies**
  - @dank074/discord-video-stream: 5.0.1 → 6.0.0

<sup>Written for commit 46de0f832fd81f0dfe02b6f29e4519374a3ccebd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

