### PR TITLE
Update upload.ts

### DIFF
--- a/src/server/routes/upload.ts
+++ b/src/server/routes/upload.ts
@@ -29,7 +29,8 @@ router.post("/api/remote_upload", upload.single("link"), async (req, res) => {
  	try {
  		// First, get the file info to determine size
  		const headResponse = await axios.head(link, { httpsAgent: agent });
- 		const totalSize = parseInt(headResponse.headers['content-length'], 10);
+ 		const contentLength = headResponse.headers['content-length'];
+ 		const totalSize = parseInt(String(contentLength || 0), 10);
 
  		// Set up progress tracking
  		let downloaded = 0;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes remote upload size parsing when the server doesn't return a `content-length` header, defaulting the file size to 0 instead of failing.

<sup>Written for commit b02ba668c2962923e80e7b044c3e587a4a9cee7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ysdragon/StreamBot/pull/165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

